### PR TITLE
Update pushNotification

### DIFF
--- a/src/Components/Common/PushSubscribePrompt.js
+++ b/src/Components/Common/PushSubscribePrompt.js
@@ -49,6 +49,9 @@ function PushSubscribePromt(){
                     setSubscribed(false);
                 }
             } catch(err){
+                if(Notification.permission === 'denied'){
+                    setBlocked(true);
+                }
                 console.log('An error occurred while subscribing.')
                 console.error(err);
                 // showToken('Error retrieving registration token. ', err);


### PR DESCRIPTION
**Before changes**
![err](https://user-images.githubusercontent.com/55601795/109022263-ad2c1a80-76e1-11eb-85c4-8f94c7d0c8bb.gif)

**After changes**
![after](https://user-images.githubusercontent.com/55601795/109022867-3fccb980-76e2-11eb-9eaa-def1e41662dd.gif)

I noticed an issue while using. If a user disables the permission for notification, it console logs that error as well as shows it in the UI. I guess instead of console logging the data it's better to first check and setBlocked as 'true', so that the error doesn't reflect in the UI. If it seems fine to you, kindly merge my PR.